### PR TITLE
Allow multi features creation

### DIFF
--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -276,11 +276,11 @@ function featuregrid(state = emptyResultsState, action) {
     case CREATE_NEW_FEATURE: {
         let id = uuid.v1();
         return assign({}, state, {
-            newFeatures: action.features.map(f => ({...f, _new: true, id: id, type: "Feature",
-                geometry: null
+            newFeatures: action.features.map(f => ({...f, _new: true, id: f.id ? f.id : id, type: "Feature",
+                geometry: f.geometry ? f.geometry : null
             })),
-            select: action.features.map(f => ({...f, _new: true, id: id, type: "Feature",
-                geometry: null
+            select: action.features.map(f => ({...f, _new: true, id: f.id ? f.id : id, type: "Feature",
+                geometry: f.geometry ? f.geometry : null
             }))
         });
     }


### PR DESCRIPTION
## Description
allow this method to use more than one feature, as the action CREATE_NEW_FEATURE expect

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
If we want to create multiple features directly (using the action CREATE_NEW_FEATURE with options "features"), id and geometry are force to be the same for all created features.
#<issue>

**What is the new behavior?**
To avoid this behavior, user should initialize at least the id of each feature to not override all features.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
