### PR TITLE
Adding action/epics addTransformer feature to print module

### DIFF
--- a/web/client/actions/__tests__/print-test.js
+++ b/web/client/actions/__tests__/print-test.js
@@ -12,6 +12,7 @@ import {
     PRINT_CAPABILITIES_LOADED,
     PRINT_CAPABILITIES_ERROR,
     SET_PRINT_PARAMETER,
+    ADD_PRINT_TRANSFORMER,
     CONFIGURE_PRINT_MAP,
     CHANGE_PRINT_ZOOM_LEVEL,
     CHANGE_MAP_PRINT_PREVIEW,
@@ -21,6 +22,7 @@ import {
     PRINT_CANCEL,
     loadPrintCapabilities,
     setPrintParameter,
+    addPrintTransformer,
     configurePrintMap,
     changePrintZoomLevel,
     changeMapPrintPreview,
@@ -61,6 +63,15 @@ describe('Test correctness of the print actions', () => {
         expect(retVal.type).toBe(SET_PRINT_PARAMETER);
         expect(retVal.name).toBe('name');
         expect(retVal.value).toBe('val');
+    });
+
+    it('addPrintTransformer', () => {
+        const retVal = addPrintTransformer('transformerName', () => "mycustom_transformer", 1.5);
+        expect(retVal).toExist();
+        expect(retVal.type).toBe(ADD_PRINT_TRANSFORMER);
+        expect(retVal.name).toBe('transformerName');
+        expect(retVal.transformer()).toBe('mycustom_transformer');
+        expect(retVal.position).toBe(1.5);
     });
 
     it('configurePrintMap', () => {

--- a/web/client/actions/print.js
+++ b/web/client/actions/print.js
@@ -10,6 +10,7 @@ export const PRINT_CAPABILITIES_ERROR = 'PRINT_CAPABILITIES_ERROR';
 
 export const SET_PRINT_PARAMETER = 'SET_PRINT_PARAMETER';
 export const ADD_PRINT_PARAMETER = 'ADD_PRINT_PARAMETER';
+export const ADD_PRINT_TRANSFORMER = 'ADD_PRINT_TRANSFORMER';
 export const CONFIGURE_PRINT_MAP = 'CONFIGURE_PRINT_MAP';
 export const CHANGE_PRINT_ZOOM_LEVEL = 'CHANGE_PRINT_ZOOM_LEVEL';
 export const CHANGE_MAP_PRINT_PREVIEW = 'CHANGE_MAP_PRINT_PREVIEW';
@@ -111,6 +112,15 @@ export function addPrintParameter(name, value) {
         type: ADD_PRINT_PARAMETER,
         name,
         value
+    };
+}
+
+export function addPrintTransformer(name, transformer, position) {
+    return {
+        type: ADD_PRINT_TRANSFORMER,
+        name,
+        transformer,
+        position
     };
 }
 

--- a/web/client/actions/print.js
+++ b/web/client/actions/print.js
@@ -11,6 +11,7 @@ export const PRINT_CAPABILITIES_ERROR = 'PRINT_CAPABILITIES_ERROR';
 export const SET_PRINT_PARAMETER = 'SET_PRINT_PARAMETER';
 export const ADD_PRINT_PARAMETER = 'ADD_PRINT_PARAMETER';
 export const ADD_PRINT_TRANSFORMER = 'ADD_PRINT_TRANSFORMER';
+export const PRINT_TRANSFORMER_ADDED = 'PRINT_TRANSFORMER_ADDED';
 export const CONFIGURE_PRINT_MAP = 'CONFIGURE_PRINT_MAP';
 export const CHANGE_PRINT_ZOOM_LEVEL = 'CHANGE_PRINT_ZOOM_LEVEL';
 export const CHANGE_MAP_PRINT_PREVIEW = 'CHANGE_MAP_PRINT_PREVIEW';
@@ -121,6 +122,13 @@ export function addPrintTransformer(name, transformer, position) {
         name,
         transformer,
         position
+    };
+}
+
+export function printTransformerAdded(name) {
+    return {
+        type: PRINT_TRANSFORMER_ADDED,
+        name
     };
 }
 

--- a/web/client/epics/__tests__/print-test.js
+++ b/web/client/epics/__tests__/print-test.js
@@ -8,7 +8,7 @@
 
 import expect from 'expect';
 import {
-    addPrintTransformer
+    addPrintTransformer, PRINT_TRANSFORMER_ADDED
 } from '../../actions/print';
 
 import {
@@ -19,12 +19,13 @@ import {
     addPrintTransformerEpic
 } from '../print';
 
-import { testEpic} from './epicTestUtils';
+import { testEpic } from './epicTestUtils';
 
 
 describe('Test the print epics', () => {
 
     it('Epics Add transformer', function(done) {
+        const chainLengthBeforeTest = getSpecTransformerChain().length;
         testEpic(
             addPrintTransformerEpic,
             1,
@@ -32,8 +33,9 @@ describe('Test the print epics', () => {
             actions => {
                 try {
                     expect(actions.length).toEqual(1);
+                    expect(actions[0].type).toEqual(PRINT_TRANSFORMER_ADDED);
                     const chain = getSpecTransformerChain();
-                    expect(chain.length).toBe(4);
+                    expect(chain.length).toBe(chainLengthBeforeTest + 1);
                     expect(chain[3].name).toBe("transformer_mock");
                     expect(chain[3].transformer()).toBe("mycustom_transformer");
                     done();
@@ -45,17 +47,19 @@ describe('Test the print epics', () => {
     });
 
     it('Epics Add transformer with position', function(done) {
+        const chainLengthBeforeTest = getSpecTransformerChain().length;
         testEpic(
             addPrintTransformerEpic,
             1,
-            addPrintTransformer('transformer_mock', () => "mycustom_transformer", 1.5),
+            addPrintTransformer('transformer_mock_pos', () => "mycustom_transformer_pos", 1.5),
             actions => {
                 try {
                     expect(actions.length).toEqual(1);
+                    expect(actions[0].type).toEqual(PRINT_TRANSFORMER_ADDED);
                     const chain = getSpecTransformerChain();
-                    expect(chain.length).toBe(4);
-                    expect(chain[2].name).toBe("transformer_mock");
-                    expect(chain[2].transformer()).toBe("mycustom_transformer");
+                    expect(chain.length).toBe(chainLengthBeforeTest + 1);
+                    expect(chain[2].name).toBe("transformer_mock_pos");
+                    expect(chain[2].transformer()).toBe("mycustom_transformer_pos");
                     done();
                 } catch (e) {
                     done(e);

--- a/web/client/epics/__tests__/print-test.js
+++ b/web/client/epics/__tests__/print-test.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import {
+    addPrintTransformer
+} from '../../actions/print';
+
+import {
+    getSpecTransformerChain
+} from '../../utils/PrintUtils';
+
+import {
+    addPrintTransformerEpic
+} from '../print';
+
+import { testEpic} from './epicTestUtils';
+
+
+describe('Test the print epics', () => {
+
+    it('Epics Add transformer', function(done) {
+        testEpic(
+            addPrintTransformerEpic,
+            1,
+            addPrintTransformer('transformer_mock', () => "mycustom_transformer"),
+            actions => {
+                try {
+                    expect(actions.length).toEqual(1);
+                    const chain = getSpecTransformerChain();
+                    expect(chain.length).toBe(4);
+                    expect(chain[3].name).toBe("transformer_mock");
+                    expect(chain[3].transformer()).toBe("mycustom_transformer");
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }, {}
+        );
+    });
+
+    it('Epics Add transformer with position', function(done) {
+        testEpic(
+            addPrintTransformerEpic,
+            1,
+            addPrintTransformer('transformer_mock', () => "mycustom_transformer", 1.5),
+            actions => {
+                try {
+                    expect(actions.length).toEqual(1);
+                    const chain = getSpecTransformerChain();
+                    expect(chain.length).toBe(4);
+                    expect(chain[2].name).toBe("transformer_mock");
+                    expect(chain[2].transformer()).toBe("mycustom_transformer");
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }, {}
+        );
+    });
+});

--- a/web/client/epics/print.js
+++ b/web/client/epics/print.js
@@ -8,7 +8,7 @@
 
 
 import Rx from 'rxjs';
-import {ADD_PRINT_TRANSFORMER} from '../actions/print';
+import { ADD_PRINT_TRANSFORMER, printTransformerAdded } from '../actions/print';
 import { addTransformer } from '../utils/PrintUtils';
 
 
@@ -16,7 +16,7 @@ export const addPrintTransformerEpic = (action$) =>
     action$.ofType(ADD_PRINT_TRANSFORMER)
         .switchMap((action) => {
             addTransformer(action.name, action.transformer, action.position);
-            return Rx.Observable.empty();
+            return Rx.Observable.of(printTransformerAdded(action.name));
         });
 
 export default {

--- a/web/client/epics/print.js
+++ b/web/client/epics/print.js
@@ -15,10 +15,8 @@ import { addTransformer } from '../utils/PrintUtils';
 export const addPrintTransformerEpic = (action$) =>
     action$.ofType(ADD_PRINT_TRANSFORMER)
         .switchMap((action) => {
-            const {name, transformer, position} = action;
-            return Rx.Observable.of(
-                addTransformer(name, transformer, position)
-            );
+            addTransformer(action.name, action.transformer, action.position);
+            return Rx.Observable.empty();
         });
 
 export default {

--- a/web/client/epics/print.js
+++ b/web/client/epics/print.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+
+import Rx from 'rxjs';
+import {ADD_PRINT_TRANSFORMER} from '../actions/print';
+import { addTransformer } from '../utils/PrintUtils';
+
+
+export const addPrintTransformerEpic = (action$) =>
+    action$.ofType(ADD_PRINT_TRANSFORMER)
+        .switchMap((action) => {
+            const {name, transformer, position} = action;
+            return Rx.Observable.of(
+                addTransformer(name, transformer, position)
+            );
+        });
+
+export default {
+    addPrintTransformerEpic
+};

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -22,6 +22,7 @@ import { configurePrintMap, printError, printSubmit, printSubmitting, addPrintPa
 import Message from '../components/I18N/Message';
 import Dialog from '../components/misc/Dialog';
 import printReducers from '../reducers/print';
+import printEpics from '../epics/print';
 import { printSpecificationSelector } from "../selectors/print";
 import { layersSelector } from '../selectors/layers';
 import { currentLocaleSelector } from '../selectors/locale';
@@ -653,5 +654,6 @@ export default {
             priority: 2
         }
     }),
-    reducers: {print: printReducers}
+    reducers: {print: printReducers},
+    epics: {...printEpics}
 };

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -347,6 +347,9 @@ export function resetDefaultPrintingService() {
  * @example
  * // add a transformer to append a new property to the spec
  * addTransformer("mytransform", (state, spec) => ({...spec, newprop: state.print.myprop}))
+ *
+ * If you need to use addTransformer in an extension, use action ADD_PRINT_TRANSFORMER from print module
+ * Otherwise, the let userTransformerChain are copy to your extension and not override the reference in the print module of MapStore2 framework
  */
 export function addTransformer(name, transformer, position) {
     userTransformerChain = addOrReplaceTransformers(userTransformerChain, [{name, transformer, position}]);


### PR DESCRIPTION
Same PR as this one : https://github.com/geosolutions-it/MapStore2/pull/9309
Include migration reducer to epics.

## Description

Adding addTransformer feature to the print module reducer/action for use this function outside of the MapStore2 framework code (like an MapStore2-geOrchestra extension).

<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
When you develop a new extension for Mapstore2-Georchestra, if you [import addTransformer](https://github.com/geosolutions-it/MapStore2/blob/a00d669c5149d8546bb8fcd6a853929abdd672a4/web/client/plugins/Print.jsx#L194-L201) in your MapStore2-geOrchestra extension code and use it, the adding tranformer is in a local copy of the final userTransformerChain variable.
[For now, components retrieved from MapStore (using the import) will be a copy of the existing ones](https://github.com/geosolutions-it/MapStoreExtension#limitations)

So, when you open the print module and click on "Print", the print module call [getSpecTransformerChain](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/utils/PrintUtils.js#L310) and use the variable userTransformerChain  which is not the same as your local copy userTransformerChain  modify by your local copy of addtransformer.
Your transform is not apply.


#<issue>

**What is the new behavior?**
For fix it and use addTransform from outside (MapStore2-geOrchestra extension), I propose to add an action and reducers to the print module for calling the addTransform methode through an action ; Print module in catch this action and apply the addTransformer method in the framework.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information