### PR TITLE
Fix addTransformer epics

### DIFF
--- a/web/client/actions/print.js
+++ b/web/client/actions/print.js
@@ -11,6 +11,7 @@ export const PRINT_CAPABILITIES_ERROR = 'PRINT_CAPABILITIES_ERROR';
 export const SET_PRINT_PARAMETER = 'SET_PRINT_PARAMETER';
 export const ADD_PRINT_PARAMETER = 'ADD_PRINT_PARAMETER';
 export const ADD_PRINT_TRANSFORMER = 'ADD_PRINT_TRANSFORMER';
+export const PRINT_TRANSFORMER_ADDED = 'PRINT_TRANSFORMER_ADDED';
 export const CONFIGURE_PRINT_MAP = 'CONFIGURE_PRINT_MAP';
 export const CHANGE_PRINT_ZOOM_LEVEL = 'CHANGE_PRINT_ZOOM_LEVEL';
 export const CHANGE_MAP_PRINT_PREVIEW = 'CHANGE_MAP_PRINT_PREVIEW';
@@ -121,6 +122,13 @@ export function addPrintTransformer(name, transformer, position) {
         name,
         transformer,
         position
+    };
+}
+
+export function printTransformerAdded(name) {
+    return {
+        type: PRINT_TRANSFORMER_ADDED,
+        name
     };
 }
 

--- a/web/client/epics/__tests__/print-test.js
+++ b/web/client/epics/__tests__/print-test.js
@@ -8,7 +8,7 @@
 
 import expect from 'expect';
 import {
-    addPrintTransformer
+    addPrintTransformer, PRINT_TRANSFORMER_ADDED
 } from '../../actions/print';
 
 import {
@@ -19,12 +19,13 @@ import {
     addPrintTransformerEpic
 } from '../print';
 
-import { testEpic} from './epicTestUtils';
+import { testEpic } from './epicTestUtils';
 
 
 describe('Test the print epics', () => {
 
     it('Epics Add transformer', function(done) {
+        const chainLengthBeforeTest = getSpecTransformerChain().length;
         testEpic(
             addPrintTransformerEpic,
             1,
@@ -32,8 +33,9 @@ describe('Test the print epics', () => {
             actions => {
                 try {
                     expect(actions.length).toEqual(1);
+                    expect(actions[0].type).toEqual(PRINT_TRANSFORMER_ADDED);
                     const chain = getSpecTransformerChain();
-                    expect(chain.length).toBe(4);
+                    expect(chain.length).toBe(chainLengthBeforeTest + 1);
                     expect(chain[3].name).toBe("transformer_mock");
                     expect(chain[3].transformer()).toBe("mycustom_transformer");
                     done();
@@ -45,17 +47,18 @@ describe('Test the print epics', () => {
     });
 
     it('Epics Add transformer with position', function(done) {
+        const chainLengthBeforeTest = getSpecTransformerChain().length;
         testEpic(
             addPrintTransformerEpic,
             1,
-            addPrintTransformer('transformer_mock', () => "mycustom_transformer", 1.5),
+            addPrintTransformer('transformer_mock_pos', () => "mycustom_transformer_pos", 1.5),
             actions => {
                 try {
                     expect(actions.length).toEqual(1);
                     const chain = getSpecTransformerChain();
-                    expect(chain.length).toBe(4);
-                    expect(chain[2].name).toBe("transformer_mock");
-                    expect(chain[2].transformer()).toBe("mycustom_transformer");
+                    expect(chain.length).toBe(chainLengthBeforeTest + 1);
+                    expect(chain[2].name).toBe("transformer_mock_pos");
+                    expect(chain[2].transformer()).toBe("mycustom_transformer_pos");
                     done();
                 } catch (e) {
                     done(e);

--- a/web/client/epics/print.js
+++ b/web/client/epics/print.js
@@ -8,17 +8,15 @@
 
 
 import Rx from 'rxjs';
-import {ADD_PRINT_TRANSFORMER} from '../actions/print';
+import { ADD_PRINT_TRANSFORMER, printTransformerAdded } from '../actions/print';
 import { addTransformer } from '../utils/PrintUtils';
 
 
 export const addPrintTransformerEpic = (action$) =>
     action$.ofType(ADD_PRINT_TRANSFORMER)
         .switchMap((action) => {
-            const {name, transformer, position} = action;
-            return Rx.Observable.of(
-                addTransformer(name, transformer, position)
-            );
+            addTransformer(action.name, action.transformer, action.position);
+            return Rx.Observable.of(printTransformerAdded(action.name));
         });
 
 export default {


### PR DESCRIPTION
Fix addTransformer epics by returning à new action 'PRINT_TRANSFORMER_ADDED' instead of a null action

## Description
In the epics, I return a null action. This causes unwanted side effects.
We suggest to return a new action call 'PRINT_TRANSFORMER_ADDED', with the printTransformer name in arg.

Plus Update some code style.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information